### PR TITLE
Migrate from reqwest to ureq.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["api-bindings", "games"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.10", features = ["blocking"] }
 chrono = { version = "0.4", features = ["serde"] }
 percent-encoding = "2.1"
 itertools = "0.9"
+ureq = "2.0.1"
 
 [dev-dependencies]
 rayon = "1"

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -64,7 +64,6 @@ pub fn rullings() -> crate::Result<UriIter<Ruling>> {
 
 #[cfg(test)]
 mod tests {
-
     #[test]
     #[ignore]
     fn oracle_cards() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! This module exposes the possible errors this crate has, and ways to interact
 //! with them.
 use itertools::Itertools;
-use reqwest::Error as ReqwestError;
+use ureq::Error as UreqError;
 use serde::{Deserialize, Serialize};
 use serde_json::Error as SerdeError;
 
@@ -18,7 +18,7 @@ pub enum Error {
     /// [open an issue](https://github.com/Mendess2526/scryfall-rs/issues).
     JsonError(SerdeError),
     /// Something went wrong when making the HTTP request.
-    ReqwestError(ReqwestError),
+    UreqError(UreqError),
     /// Scryfall error. Please refer to the [official docs](https://scryfall.com/docs/api/errors).
     ScryfallError(ScryfallError),
     /// Other.
@@ -49,9 +49,9 @@ impl From<SerdeError> for Error {
 }
 
 #[doc(hidden)]
-impl From<ReqwestError> for Error {
-    fn from(error: ReqwestError) -> Self {
-        Error::ReqwestError(error)
+impl From<UreqError> for Error {
+    fn from(error: UreqError) -> Self {
+        Error::UreqError(error)
     }
 }
 
@@ -73,7 +73,7 @@ impl fmt::Display for Error {
         use Error::*;
         match self {
             JsonError(e) => write!(f, "Error deserializing json: {}", e),
-            ReqwestError(e) => write!(f, "Error making request: {}", e),
+            UreqError(e) => write!(f, "Error making request: {}", e),
             ScryfallError(e) => write!(
                 f,
                 "Scryfall error:\n\tdetails: {}{}",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
 //! This module exposes the possible errors this crate has, and ways to interact
 //! with them.
 use itertools::Itertools;
-use ureq::Error as UreqError;
 use serde::{Deserialize, Serialize};
 use serde_json::Error as SerdeError;
+use ureq::Error as UreqError;
 
 use std::fmt;
 
@@ -83,10 +83,7 @@ impl fmt::Display for Error {
                 } else {
                     format!(
                         "\n\twarnings:\n{}",
-                        e.warnings
-                            .iter()
-                            .map(|w| format!("\t\t{}", w))
-                            .join("\n")
+                        e.warnings.iter().map(|w| format!("\t\t{}", w)).join("\n")
                     )
                 }
             ),

--- a/src/ruling.rs
+++ b/src/ruling.rs
@@ -115,12 +115,12 @@ impl Ruling {
     /// # Examples
     /// ```rust
     /// use scryfall::ruling::Ruling;
-    /// match Ruling::set_and_number("ima", 65).next() {
+    /// match Ruling::set_and_number("bfz", 17).next() {
     ///     Some(rulings) => assert_eq!(
     ///         rulings
     ///             .unwrap()
     ///             .iter()
-    ///             .filter(|r| r.comment == "If the target spell is an illegal target when Mana Drain tries to resolve, it won’t resolve and none of its effects will happen. You won’t get any mana.")
+    ///             .filter(|r| r.comment == "Yes, your opponent can’t even. We know.")
     ///             .count(),
     ///         1
     ///     ),

--- a/src/util/uri.rs
+++ b/src/util/uri.rs
@@ -12,7 +12,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// A URI that will fetch something of a defined type `T`.
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[serde(transparent)]
-pub struct URI<T>(String, PhantomData<T>);
+pub struct URI<T>(String, PhantomData<fn() -> T>);
 
 impl<T: DeserializeOwned> From<String> for URI<T> {
     fn from(s: String) -> Self {


### PR DESCRIPTION
Use [ureq](https://lib.rs/ureq) instead of reqwest. This crate uses the blocking API already so it doesn't benefit from the additional async dependencies of reqwest.