### PR TITLE
Use tinyvec crate to store SetCode bytes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 percent-encoding = "2.1"
 itertools = "0.9"
 ureq = "2.0.1"
+tinyvec = "1.1.1"
 
 [dev-dependencies]
 rayon = "1"


### PR DESCRIPTION
This makes SetCode 8 bytes instead of 7 bytes as with the previous enum.

`tinyvec` is already in the dependency tree, as a dependency of `url`.