### PR TITLE
Cache BulkDataFile downloads in tmp dir.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,14 @@ readme = "README.md"
 keywords = ["mtg", "Magic", "API", "Scryfall"]
 categories = ["api-bindings", "games"]
 
+[features]
+default = ["bulk_caching"]
+bulk_caching = ["heck"]
+
 [dependencies]
+cfg-if = "1.0.0"
 chrono = { version = "0.4.19", features = ["serde"] }
-heck = "0.3.2"
+heck = { version = "0.3.2", optional = true }
 httpstatus = "0.1.2"
 itertools = "0.10.0"
 once_cell = "1.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings", "games"]
 
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
+heck = "0.3.2"
 httpstatus = "0.1.2"
 itertools = "0.10.0"
 once_cell = "1.5.2"

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -144,34 +144,34 @@ impl<T: DeserializeOwned> BulkDataFile<T> {
 /// An iterator containing one Scryfall card object for each Oracle ID on
 /// Scryfall. The chosen sets for the cards are an attempt to return the most
 /// up-to-date recognizable version of the card.
-pub fn oracle_cards() -> crate::Result<Vec<Card>> {
-    BulkDataFile::of_type("oracle_cards")?.load()
+pub fn oracle_cards() -> crate::Result<impl Iterator<Item = crate::Result<Card>>> {
+    BulkDataFile::of_type("oracle_cards")?.load_iter()
 }
 
 /// An iterator of Scryfall card objects that together contain all unique
 /// artworks. The chosen cards promote the best image scans.
-pub fn unique_artwork() -> crate::Result<Vec<Card>> {
-    BulkDataFile::of_type("unique_artwork")?.load()
+pub fn unique_artwork() -> crate::Result<impl Iterator<Item = crate::Result<Card>>> {
+    BulkDataFile::of_type("unique_artwork")?.load_iter()
 }
 
 /// An iterator containing every card object on Scryfall in English or the
 /// printed language if the card is only available in one language.
-pub fn default_cards() -> crate::Result<Vec<Card>> {
-    BulkDataFile::of_type("default_cards")?.load()
+pub fn default_cards() -> crate::Result<impl Iterator<Item = crate::Result<Card>>> {
+    BulkDataFile::of_type("default_cards")?.load_iter()
 }
 
 /// An iterator of every card object on Scryfall in every language.
 ///
 /// # Note
 /// This currently takes about 2GB of RAM before returning 👀.
-pub fn all_cards() -> crate::Result<Vec<Card>> {
-    BulkDataFile::of_type("all_cards")?.load()
+pub fn all_cards() -> crate::Result<impl Iterator<Item = crate::Result<Card>>> {
+    BulkDataFile::of_type("all_cards")?.load_iter()
 }
 
 /// An iterator of all Rulings on Scryfall. Each ruling refers to cards via an
 /// `oracle_id`.
-pub fn rulings() -> crate::Result<Vec<Ruling>> {
-    BulkDataFile::of_type("rulings")?.load()
+pub fn rulings() -> crate::Result<impl Iterator<Item = crate::Result<Ruling>>> {
+    BulkDataFile::of_type("rulings")?.load_iter()
 }
 
 #[cfg(test)]
@@ -179,31 +179,41 @@ mod tests {
     #[test]
     #[ignore]
     fn oracle_cards() {
-        super::oracle_cards().expect("Couldn't get the bulk object");
+        for card in super::oracle_cards().expect("Couldn't get the bulk object") {
+            card.unwrap();
+        }
     }
 
     #[test]
     #[ignore]
     fn unique_artwork() {
-        super::unique_artwork().expect("Couldn't get the bulk object");
+        for card in super::unique_artwork().expect("Couldn't get the bulk object") {
+            card.unwrap();
+        }
     }
 
     #[test]
     #[ignore]
     fn default_cards() {
-        super::default_cards().expect("Couldn't get the bulk object");
+        for card in super::default_cards().expect("Couldn't get the bulk object") {
+            card.unwrap();
+        }
     }
 
     #[test]
     #[ignore]
     fn all_cards() {
-        super::all_cards().expect("Couldn't get the bulk object");
+        for card in super::all_cards().expect("Couldn't get the bulk object") {
+            card.unwrap();
+        }
     }
 
     #[test]
     #[ignore]
     fn rulings() {
-        super::rulings().expect("Couldn't get the bulk object");
+        for ruling in super::rulings().expect("Couldn't get the bulk object") {
+            ruling.unwrap();
+        }
     }
 
     #[test]

--- a/src/card/rarity.rs
+++ b/src/card/rarity.rs
@@ -10,4 +10,5 @@ pub enum Rarity {
     Uncommon,
     Rare,
     Mythic,
+    Bonus,
 }

--- a/src/card/rarity.rs
+++ b/src/card/rarity.rs
@@ -11,4 +11,5 @@ pub enum Rarity {
     Rare,
     Mythic,
     Bonus,
+    Special,
 }

--- a/src/card/rarity.rs
+++ b/src/card/rarity.rs
@@ -9,7 +9,7 @@ pub enum Rarity {
     Common,
     Uncommon,
     Rare,
+    Special,
     Mythic,
     Bonus,
-    Special,
 }

--- a/src/card_searcher.rs
+++ b/src/card_searcher.rs
@@ -711,6 +711,7 @@ impl Param for RarityParam {
                 Rarity::Uncommon => "u",
                 Rarity::Rare => "r",
                 Rarity::Mythic => "m",
+                Rarity::Bonus => "b",
             }
         )
     }

--- a/src/card_searcher.rs
+++ b/src/card_searcher.rs
@@ -710,9 +710,9 @@ impl Param for RarityParam {
                 Rarity::Common => "c",
                 Rarity::Uncommon => "u",
                 Rarity::Rare => "r",
+                Rarity::Special => "s",
                 Rarity::Mythic => "m",
                 Rarity::Bonus => "b",
-                Rarity::Special => "s",
             }
         )
     }

--- a/src/card_searcher.rs
+++ b/src/card_searcher.rs
@@ -712,6 +712,7 @@ impl Param for RarityParam {
                 Rarity::Rare => "r",
                 Rarity::Mythic => "m",
                 Rarity::Bonus => "b",
+                Rarity::Special => "s",
             }
         )
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! This module exposes the possible errors this crate has, and ways to interact
 //! with them.
-use std::fmt;
+use std::{fmt, io};
 
 use httpstatus::StatusCode;
 use itertools::Itertools;
@@ -33,6 +33,10 @@ pub enum Error {
     /// HTTP error with status code.
     #[error("HTTP error: {0}")]
     HttpError(StatusCode),
+
+    /// IO error.
+    #[error("IO error: {0}")]
+    IoError(#[from] io::Error),
 
     /// Other.
     #[error("{0}")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,8 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer};
 use url::Url;
 
+pub(crate) mod array_stream_reader;
+
 /// The [scryfall](https://scryfall.com/docs/api) endpoint.
 pub static ROOT_URL: Lazy<Url> = Lazy::new(|| Url::parse("https://api.scryfall.com/").unwrap());
 /// The [cards](https://scryfall.com/docs/api/cards) endpoint.

--- a/src/util/array_stream_reader.rs
+++ b/src/util/array_stream_reader.rs
@@ -1,0 +1,117 @@
+use std::io;
+use std::io::BufReader;
+
+/// An implementation of `Read` that transforms JSON input where the outermost
+/// structure is an array. The enclosing brackets and commas are removed,
+/// causing the items to be adjacent to one another. This works with
+/// [`serde_json::StreamDeserializer`].
+pub(crate) struct ArrayStreamReader<T> {
+    inner: T,
+    depth: Option<usize>,
+    inside_string: bool,
+    escape_next: bool,
+}
+
+impl<T: io::Read> ArrayStreamReader<T> {
+    pub(crate) fn new_buffered(inner: T) -> BufReader<Self> {
+        BufReader::new(ArrayStreamReader {
+            inner,
+            depth: None,
+            inside_string: false,
+            escape_next: false,
+        })
+    }
+}
+
+#[inline]
+fn do_copy(dst: &mut [u8], src: &[u8], len: usize) {
+    if len == 1 {
+        dst[0] = src[0]; // Avoids memcpy call.
+    } else {
+        dst[..len].copy_from_slice(&src[..len]);
+    }
+}
+
+impl<T: io::Read> io::Read for ArrayStreamReader<T> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let mut tmp = vec![0u8; buf.len()];
+
+        // The outer loop is here in case every byte was skipped, which can happen
+        // easily if
+        // `buf.len()` is 1. In this situation, the operation is retried until either no
+        // bytes are read from the inner stream, or at least 1 byte is written to `buf`.
+        loop {
+            let byte_count = self.inner.read(&mut tmp)?;
+            if byte_count == 0 {
+                return if self.depth.is_some() {
+                    Err(io::ErrorKind::UnexpectedEof.into())
+                } else {
+                    Ok(0)
+                };
+            }
+
+            let mut tmp_pos = 0;
+            let mut buf_pos = 0;
+            for (i, b) in tmp.iter().cloned().enumerate() {
+                if self.depth.is_none() {
+                    match b {
+                        b'[' => {
+                            self.depth = Some(0);
+                            tmp_pos = i + 1;
+                        },
+                        b if b.is_ascii_whitespace() => {},
+                        b'\0' => break,
+                        _ => return Err(io::ErrorKind::InvalidData.into()),
+                    }
+                    continue;
+                }
+
+                if self.inside_string {
+                    match b {
+                        b'\\' => self.escape_next = true,
+                        b'"' if !self.escape_next => self.inside_string = false,
+                        _ if self.escape_next => self.escape_next = false,
+                        _ => {},
+                    }
+                    continue;
+                }
+
+                let depth = self.depth.unwrap();
+                match b {
+                    b'[' | b'{' => self.depth = Some(depth + 1),
+                    b']' | b'}' if depth > 0 => self.depth = Some(depth - 1),
+                    b'"' => self.inside_string = true,
+                    b'}' if depth == 0 => return Err(io::ErrorKind::InvalidData.into()),
+                    b',' | b']' if depth == 0 => {
+                        let len = i - tmp_pos;
+                        do_copy(&mut buf[buf_pos..], &tmp[tmp_pos..], len);
+                        tmp_pos = i + 1;
+                        buf_pos += len;
+                        if b == b']' {
+                            // Reached the end of outer array. If another array follows, the stream
+                            // will continue.
+                            self.depth = None;
+                        }
+                    },
+                    _ => {},
+                }
+            }
+
+            if tmp_pos < byte_count {
+                let len = byte_count - tmp_pos;
+                do_copy(&mut buf[buf_pos..], &tmp[tmp_pos..], len);
+                buf_pos += len;
+            }
+
+            if buf_pos > 0 {
+                // If at least some data was read, return with the amount. Otherwise, the outer
+                // loop will try again.
+                return Ok(buf_pos);
+            }
+        }
+    }
+}

--- a/src/util/array_stream_reader.rs
+++ b/src/util/array_stream_reader.rs
@@ -72,9 +72,9 @@ impl<T: io::Read> io::Read for ArrayStreamReader<T> {
 
                 if self.inside_string {
                     match b {
+                        _ if self.escape_next => self.escape_next = false,
                         b'\\' => self.escape_next = true,
                         b'"' if !self.escape_next => self.inside_string = false,
-                        _ if self.escape_next => self.escape_next = false,
                         _ => {},
                     }
                     continue;

--- a/src/util/array_stream_reader.rs
+++ b/src/util/array_stream_reader.rs
@@ -123,8 +123,9 @@ impl<T: io::Read> io::Read for ArrayStreamReader<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Read;
+
+    use super::*;
 
     fn _read_bytes(src: &[u8]) -> io::Result<Vec<u8>> {
         let mut dst = Vec::with_capacity(src.len());
@@ -150,13 +151,22 @@ mod tests {
 
     #[test]
     fn arrays_with_items() {
-        assert_eq!(_read_bytes(br#"[{}, "hello"]"#).unwrap(), br#"{}  "hello" "#);
+        assert_eq!(
+            _read_bytes(br#"[{}, "hello"]"#).unwrap(),
+            br#"{}  "hello" "#
+        );
         assert_eq!(_read_bytes(b"[[[]]]").unwrap(), b"[[]] ");
-        assert_eq!(_read_bytes(b"[true, null]\n[false]").unwrap(), b"true  null false ");
+        assert_eq!(
+            _read_bytes(b"[true, null]\n[false]").unwrap(),
+            b"true  null false "
+        );
     }
 
     #[test]
     fn string_escapes() {
-        assert_eq!(_read_bytes(br#"["\n\"\\{{{"]"#).unwrap(), br#""\n\"\\{{{" "#);
+        assert_eq!(
+            _read_bytes(br#"["\n\"\\{{{"]"#).unwrap(),
+            br#""\n\"\\{{{" "#
+        );
     }
 }


### PR DESCRIPTION
- Cache BulkDataFile downloads into OS temp folder.
- Add load_iter method for BulkDataFile.
- Implement bulk functions using load_iter.

Not sure about the last commit. Maybe having alternative functions
such as `oracle_cards_iter` would be preferable to changing the existing
ones.
