### PR TITLE
Scryfall API Updates

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -226,7 +226,7 @@ pub struct Card {
     pub border_color: BorderColor,
 
     /// The Scryfall ID for the card back design present on this card.
-    pub card_back_id: Uuid,
+    pub card_back_id: Option<Uuid>,
 
     /// This card’s collector number. Note that collector numbers can contain
     /// non-numeric characters, such as letters or `★`.

--- a/src/format.rs
+++ b/src/format.rs
@@ -25,6 +25,7 @@ pub enum Format {
     Premodern,
     HistoricBrawl,
     PauperCommander,
+    Alchemy,
 }
 
 impl fmt::Display for Format {
@@ -51,6 +52,7 @@ impl fmt::Display for Format {
                 Premodern => "premodern",
                 HistoricBrawl => "historicbrawl",
                 PauperCommander => "paupercommander",
+                Alchemy => "alchemy",
             }
         )
     }


### PR DESCRIPTION
Hi,

I've found two changes Scryfall have made to their API that are currently breaking scryfall-rs that this PR fixes.

1. They have added support for the [Alchemy](https://scryfall.com/search?as=grid&order=name&q=legal%3Aalchemy) format from MTG Arena
2. On the card object, the `card_back_id` field now appears to now be optional. Double sided cards no longer have the field  (e.g. Arlinn `b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02`). I have tried emailing and tweeting at @scryfall to get confirmation this is intended as their documentation doesn't list the field as able to be null/missing, but haven't heard back yet. 

Thanks for your work with this crate, I've found it super useful.

``