### PR TITLE
Add support for Explorer format

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -26,6 +26,7 @@ pub enum Format {
     HistoricBrawl,
     PauperCommander,
     Alchemy,
+    Explorer,
 }
 
 impl fmt::Display for Format {
@@ -53,6 +54,7 @@ impl fmt::Display for Format {
                 HistoricBrawl => "historicbrawl",
                 PauperCommander => "paupercommander",
                 Alchemy => "alchemy",
+                Explorer => "explorer",
             }
         )
     }

--- a/src/set/set_type.rs
+++ b/src/set/set_type.rs
@@ -52,6 +52,10 @@ pub enum SetType {
     /// A set made up of gold-bordered, oversize, or trophy cards that are not
     /// legal
     Memorabilia,
+    /// Alchemy sets
+    Alchemy,
+    /// Arsenal sets
+    Arsenal,
 }
 
 impl fmt::Display for SetType {
@@ -80,6 +84,8 @@ impl fmt::Display for SetType {
                 SetType::Promo => "promo",
                 SetType::Token => "token",
                 SetType::Memorabilia => "memorabilia",
+                SetType::Alchemy => "alchemy",
+                SetType::Arsenal => "arsenal",
             }
         )
     }


### PR DESCRIPTION
This month, a new format was released, called "Explorer".
Scryfall already added support for it and with that change it broke the card search capabilities of this library:

```
   0: Error deserializing json: unknown variant `explorer`, expected one of `standard`, `modern`, `legacy`, `vintage`, `commander`, `future`, `pauper`, `pioneer`, `penny`, `duel`, `oldschool`, `historic`, `gladiator`, `brawl`, `premodern`, `historicbrawl`, `paupercommander`, `alchemy` at line 1 column 2022
   1: unknown variant `explorer`, expected one of `standard`, `modern`, `legacy`, `vintage`, `commander`, `future`, `pauper`, `pioneer`, `penny`, `duel`, `oldschool`, `historic`, `gladiator`, `brawl`, `premodern`, `historicbrawl`, `paupercommander`, `alchemy` at line 1 column 2022
```

This patch adds the missing enumeration field `Explorer` to `enum Format`.
It does not bump the version of this library.