### PR TITLE
Fix Scryfall breaking changes

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -564,7 +564,7 @@ impl Card {
     /// # Examples
     /// ```rust
     /// use scryfall::card::Card;
-    /// match Card::card("0b81b329-4ef5-4b55-9fe7-9ed69477e96b".parse().unwrap()) {
+    /// match Card::scryfall_id("0b81b329-4ef5-4b55-9fe7-9ed69477e96b".parse().unwrap()) {
     ///     Ok(card) => assert_eq!(card.name, "Cowed by Wisdom"),
     ///     Err(e) => panic!("{:?}", e),
     /// }

--- a/src/card.rs
+++ b/src/card.rs
@@ -105,7 +105,8 @@ pub struct Card {
     /// A unique ID for this card’s oracle identity. This value is consistent
     /// across reprinted card editions, and unique among different cards with
     /// the same name (tokens, Unstable variants, etc).
-    pub oracle_id: Uuid,
+    /// If a card is reversible, the individual faces will have the `oracle_id` instead.
+    pub oracle_id: Option<Uuid>,
 
     /// A link to where you can begin paginating all re/prints for this card on
     /// Scryfall’s API.
@@ -133,7 +134,8 @@ pub struct Card {
 
     /// The card’s converted mana cost. Note that some funny cards have
     /// fractional mana costs.
-    pub cmc: f32,
+    /// If a card is reversible, the individual faces will have the `cmc` instead.
+    pub cmc: Option<f32>,
 
     /// This card’s color identity.
     pub color_identity: Vec<Color>,
@@ -209,7 +211,8 @@ pub struct Card {
     pub toughness: Option<String>,
 
     /// The type line of this card.
-    pub type_line: String,
+    /// If a card is reversible, the individual faces will have the `oracle_id` instead.
+    pub type_line: Option<String>,
     // =========================
     // endregion Gameplay Fields
     //
@@ -431,7 +434,7 @@ impl Card {
     /// # use scryfall::Card;
     /// # fn main() -> scryfall::Result<()> {
     /// let card = Card::search_random("t:Merfolk")?;
-    /// assert!(card.type_line.contains("Merfolk"));
+    /// assert!(card.type_line.unwrap().contains("Merfolk"));
     /// # Ok(())
     /// # }
     /// ```

--- a/src/card/color.rs
+++ b/src/card/color.rs
@@ -23,10 +23,16 @@ pub enum Color {
     Green = 1 << 4,
 
     /// **Do not use this!**
-    /// This variant makes no sense and should not exist, yet the tests fail without it.
+    /// This variant makes no sense and should not exist, yet some cards use it.
     /// Probably an upstream unintentional breaking change with Scryfall, such as broken data.
     #[serde(rename = "2")]
     Two = 1 << 5,
+
+    /// **Do not use this!**
+    /// This variant makes no sense and should not exist, yet some cards use it.
+    /// Probably an upstream unintentional breaking change with Scryfall, such as broken data.
+    #[serde(rename = "T")]
+    T = 1 << 6,
 }
 
 impl fmt::Display for Color {
@@ -42,6 +48,7 @@ impl fmt::Display for Color {
                 Color::Red => "R",
                 Color::Green => "G",
                 Color::Two => "2",
+                Color::T => "T",
             }
         )
     }

--- a/src/card/color.rs
+++ b/src/card/color.rs
@@ -21,6 +21,12 @@ pub enum Color {
     Red = 1 << 3,
     #[serde(rename = "G")]
     Green = 1 << 4,
+
+    /// **Do not use this!**
+    /// This variant makes no sense and should not exist, yet the tests fail without it.
+    /// Probably an upstream unintentional breaking change with Scryfall, such as broken data.
+    #[serde(rename = "2")]
+    Two = 1 << 5,
 }
 
 impl fmt::Display for Color {
@@ -35,6 +41,7 @@ impl fmt::Display for Color {
                 Color::Black => "B",
                 Color::Red => "R",
                 Color::Green => "G",
+                Color::Two => "2",
             }
         )
     }

--- a/src/card/frame_effect.rs
+++ b/src/card/frame_effect.rs
@@ -47,6 +47,14 @@ pub enum FrameEffect {
     Snow,
     /// The cards have the Lesson frame effect.
     Lesson,
+    /// The cards have the Shattered Glass frame effect.
+    ShatteredGlass,
+    /// The cards have More Than Meets the Eye™ marks.
+    ConvertDfc,
+    /// The cards have fan transforming marks.
+    FanDfc,
+    /// The cards have the Upside Down transforming marks.
+    UpsideDownDfc,
 
     /// A full art frame. Undocumented and unsupported for search.
     FullArt,
@@ -87,6 +95,10 @@ impl std::fmt::Display for FrameEffect {
                 Etched => "etched",
                 Snow => "snow",
                 Lesson => "lesson",
+                ShatteredGlass => "shatteredglass",
+                ConvertDfc => "convertdfc",
+                FanDfc => "fandfc",
+                UpsideDownDfc => "upsidedowndfc",
 
                 FullArt => "fullart",
                 Nyxborn => "nyxborn",

--- a/src/card/frame_effect.rs
+++ b/src/card/frame_effect.rs
@@ -33,8 +33,8 @@ pub enum FrameEffect {
     OriginPwDfc,
     /// The moon and Eldrazi transform marks.
     MoonEldraziDfc,
-    /// The waxing and waning crescent moon transform marks.
-    MoonReverseMoonDfc,
+    /// The waxing and waning moon transform marks.
+    WaxingAndWaningMoonDfc,
     /// A custom Showcase frame.
     Showcase,
     /// An extended art frame.
@@ -56,16 +56,15 @@ pub enum FrameEffect {
     /// The cards have the Upside Down transforming marks.
     UpsideDownDfc,
 
+    /// The waxing and waning crescent moon transform marks.
+    MoonReverseMoonDfc,
     /// A full art frame. Undocumented and unsupported for search.
     FullArt,
     /// A nyxborn card frame. Undocumented and unsupported for search.
     Nyxborn,
-    /// The waxing and waning moon transform marks. Undocumented and unsupported
-    /// for search.
-    WaxingAndWaningMoonDfc,
     /// The booster card frame. Undocumented and unsupported for search.
     Booster,
-    ///
+    /// A textless card frame. Undocumented and unsupported for search.
     Textless,
 }
 

--- a/src/card/layout.rs
+++ b/src/card/layout.rs
@@ -56,5 +56,5 @@ pub enum Layout {
     /// Art Series collectable double-faced cards.
     ArtSeries,
     /// A Magic card with two sides that are unrelated.
-    DoubleSided,
+    ReversibleCard,
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -111,60 +111,13 @@ pub mod prelude {
     pub use super::param::compare::{eq, gt, gte, lt, lte, neq};
     pub use super::param::criteria::{CardIs, PrintingIs};
     pub use super::param::value::{
-        artist,
-        artist_count,
-        banned,
-        block,
-        border_color,
-        cheapest,
-        cmc,
-        collector_number,
-        color,
-        color_count,
-        color_identity,
-        color_identity_count,
-        cube,
-        date,
-        devotion,
-        eur,
-        flavor_text,
-        format,
-        frame,
-        full_oracle_text,
-        game,
-        illustration_count,
-        in_game,
-        in_language,
-        in_rarity,
-        in_set,
-        in_set_type,
-        keyword,
-        language,
-        loyalty,
-        mana,
-        name,
-        oracle_text,
-        paper_print_count,
-        paper_set_count,
-        pow_tou,
-        power,
-        print_count,
-        produces,
-        rarity,
-        restricted,
-        set,
-        set_count,
-        set_type,
-        tix,
-        toughness,
-        type_line,
-        usd,
-        usd_foil,
-        watermark,
-        year,
-        Devotion,
-        NumProperty,
-        Regex,
+        artist, artist_count, banned, block, border_color, cheapest, cmc, collector_number, color,
+        color_count, color_identity, color_identity_count, cube, date, devotion, eur, flavor_text,
+        format, frame, full_oracle_text, game, illustration_count, in_game, in_language, in_rarity,
+        in_set, in_set_type, keyword, language, loyalty, mana, name, oracle_text,
+        paper_print_count, paper_set_count, pow_tou, power, print_count, produces, rarity,
+        restricted, set, set_count, set_type, tix, toughness, type_line, usd, usd_foil, watermark,
+        year, Devotion, NumProperty, Regex,
     };
     pub use super::param::{exact, Param};
     pub use super::query::{not, Query};
@@ -201,21 +154,19 @@ mod tests {
     fn random_works_with_search_options() {
         // `SearchOptions` can set more query params than the "cards/random" API method
         // accepts. Scryfall should ignore these and return a random card.
-        assert!(
-            SearchOptions::new()
-                .query(keyword("storm"))
-                .unique(UniqueStrategy::Art)
-                .sort(SortOrder::Usd, SortDirection::Ascending)
-                .extras(true)
-                .multilingual(true)
-                .variations(true)
-                .random()
-                .unwrap()
-                .oracle_text
-                .unwrap()
-                .to_lowercase()
-                .contains("storm")
-        );
+        assert!(SearchOptions::new()
+            .query(keyword("storm"))
+            .unique(UniqueStrategy::Art)
+            .sort(SortOrder::Usd, SortDirection::Ascending)
+            .extras(true)
+            .multilingual(true)
+            .variations(true)
+            .random()
+            .unwrap()
+            .oracle_text
+            .unwrap()
+            .to_lowercase()
+            .contains("storm"));
     }
 
     #[test]
@@ -254,12 +205,10 @@ mod tests {
 
         assert!(cards.len() >= 9, "Couldn't find the Power Nine from VMA.");
 
-        assert!(
-            cards
-                .into_iter()
-                .map(|c| c.unwrap())
-                .all(|c| c.rarity > Rarity::Mythic)
-        );
+        assert!(cards
+            .into_iter()
+            .map(|c| c.unwrap())
+            .all(|c| c.rarity > Rarity::Mythic));
     }
 
     #[test]
@@ -281,7 +230,7 @@ mod tests {
             .unwrap_or_default();
 
         assert_eq!(power, toughness);
-        assert_eq!(power + toughness, card.cmc as u32);
+        assert_eq!(power + toughness, card.cmc.unwrap() as u32);
 
         let card = Card::search(pow_tou(gt(NumProperty::Year)))
             .unwrap()

--- a/src/search/param/compare.rs
+++ b/src/search/param/compare.rs
@@ -24,8 +24,8 @@ use crate::search::param::Param;
 /// let query = cmc(gte(5)).and(type_line("planeswalker"));
 /// let card = query.random().unwrap();
 ///
-/// assert!(card.cmc as u32 >= 5);
-/// assert!(card.type_line.to_lowercase().contains("planeswalker"));
+/// assert!(card.cmc.unwrap() as u32 >= 5);
+/// assert!(card.type_line.unwrap().to_lowercase().contains("planeswalker"));
 /// ```
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Compare<T> {

--- a/src/search/param/criteria.rs
+++ b/src/search/param/criteria.rs
@@ -79,12 +79,13 @@ impl From<Criterion> for Query {
 /// # use scryfall::search::prelude::*;
 /// # fn main() -> scryfall::Result<()> {
 /// let party_member = Query::from(CardIs::Party).and(CardIs::Leveler).random()?;
+/// let type_line = party_member.type_line.unwrap();
 ///
 /// assert!(
-///     party_member.type_line.contains("Cleric")
-///         || party_member.type_line.contains("Rogue")
-///         || party_member.type_line.contains("Warrior")
-///         || party_member.type_line.contains("Wizard"),
+///     type_line.contains("Cleric")
+///         || type_line.contains("Rogue")
+///         || type_line.contains("Warrior")
+///         || type_line.contains("Wizard"),
 /// );
 /// assert!(party_member.keywords.iter().any(|kw| kw == "Level Up"));
 /// # Ok(())

--- a/src/search/param/value.rs
+++ b/src/search/param/value.rs
@@ -393,7 +393,7 @@ impl<T: TextValue> ColorValue for T {}
 /// # fn main() -> scryfall::Result<()> {
 /// use scryfall::card::Color;
 /// let five_red_devotion = devotion(Devotion::monocolor(Color::Red, 5)).random()?;
-/// assert!(five_red_devotion.cmc >= 5.0);
+/// assert!(five_red_devotion.cmc.unwrap() >= 5.0);
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
This makes all of the tests pass except for one of the ignored tests. All cards bulk data fails with "Unexpected end of file".

* Two unused color attributes, `T`, and `2`, because for some reason some cards on Scryfall require them.
* Updated the frame effects and layouts to fix deserialization errors.
* Changed `oracle_id`, `cmc`, and `type_line` to be `Option` because `ReversibleCard` layout cards don't have them, but rather they are on each face.
* Updated tests, the goal is to have everything pass, but I couldn't figure out the bulk data.

Feedback is appreciated, and I'd like to get this over the finish line since I need this library working for an app I'm building. I wish Scryfall had API versions and no breaking changes, but it seems like this will just continue to break in the future as a result.