### PR TITLE
Non-tokio runtime compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ httpstatus = "0.1"
 itertools = "0.12"
 once_cell = "1"
 percent-encoding = "2"
-reqwest = {version = "0.11.24", features = ["json" ,"blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7"
@@ -35,6 +34,7 @@ tinyvec = "1"
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde"] }
 tokio = { version = "1", features = ["macros"], optional = true }
+surf = "2.3.2"
 
 [dev-dependencies]
 strum = { version = "0.26", features = ["derive"] }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -16,8 +16,8 @@
 //! See also: [Official Docs](https://scryfall.com/docs/api/bulk-data)
 
 use std::fs::File;
-use std::io;
 use std::io::BufReader;
+use std::io::{self, Cursor};
 use std::path::Path;
 
 use cfg_if::cfg_if;
@@ -154,9 +154,9 @@ impl<T: DeserializeOwned> BulkDataFile<T> {
     /// already exists.
     pub async fn download(&self, path: impl AsRef<Path>) -> crate::Result<()> {
         let path = path.as_ref();
-        let response = self.download_uri.fetch_raw().await?;
-        let content = response.bytes().await?;
-        io::copy(&mut content.as_ref(), &mut File::create(path)?)?;
+        let mut response = self.download_uri.fetch_raw().await?;
+        let mut content = Cursor::new(response.body_bytes().await?);
+        io::copy(&mut content, &mut File::create(path)?)?;
         Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,6 @@ use std::{fmt, io};
 
 use httpstatus::StatusCode;
 use itertools::Itertools;
-use reqwest::Error as ReqwestError;
 use serde::{Deserialize, Serialize};
 use serde_json::Error as SerdeError;
 use url::ParseError as UrlParseError;
@@ -26,9 +25,9 @@ pub enum Error {
     #[error("Error parsing URL: {0}")]
     UrlParseError(#[from] UrlParseError),
 
-    /// Something went wrong when making the HTTP request.
+    /// An error occurred while performing a HTTP operation.
     #[error("Error making request: {0}")]
-    ReqwestError(Box<ReqwestError>, String),
+    HttpClientError(String),
 
     /// Scryfall error. Please refer to the [official docs](https://scryfall.com/docs/api/errors).
     #[error("Scryfall error: {0}")]
@@ -53,13 +52,10 @@ impl From<SerdeError> for Box<Error> {
     }
 }
 
-impl From<ReqwestError> for Error {
-    fn from(err: ReqwestError) -> Self {
-        let s = err
-            .url()
-            .map(|url| url.to_string())
-            .unwrap_or_else(|| format!("{}", err));
-        Error::ReqwestError(Box::new(err), s)
+impl From<surf::Error> for Error {
+    fn from(err: surf::Error) -> Self {
+        let s = err.to_string();
+        Error::HttpClientError(s)
     }
 }
 

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -64,21 +64,29 @@ impl<T: DeserializeOwned> Uri<T> {
     /// ```
     pub async fn fetch(&self) -> crate::Result<T> {
         match self.fetch_raw().await {
-            Ok(response) => match response.status().as_u16() {
-                200..=299 => Ok(response.json().await?),
-                status => Err(Error::HttpError(StatusCode::from(status))),
+            Ok(mut response) => {
+                let status = response.status();
+                if status.is_success() {
+                    Ok(response.body_json().await?)
+                } else {
+                    Err(Error::HttpError(StatusCode::from(u16::from(status))))
+                }
             },
             Err(e) => Err(e),
         }
     }
 
-    pub(crate) async fn fetch_raw(&self) -> crate::Result<reqwest::Response> {
-        match reqwest::get(self.url.clone()).await {
-            Ok(response) => match response.status().as_u16() {
-                400..=599 => Err(Error::ScryfallError(response.json().await?)),
-                _ => Ok(response),
+    pub(crate) async fn fetch_raw(&self) -> crate::Result<surf::Response> {
+        match surf::get(self.url.clone()).await {
+            Ok(mut response) => {
+                let status = response.status();
+                if status.is_client_error() || status.is_server_error() {
+                    Err(Error::ScryfallError(response.body_json().await?))
+                } else {
+                    Ok(response)
+                }
             },
-            Err(e) => Err(Error::ReqwestError(e.into(), self.url.to_string())),
+            Err(e) => Err(e.into()),
         }
     }
 }


### PR DESCRIPTION
## Why?

Make scryfall-rs usable under non-tokio async runtimes.
Reqwest is only compatible with tokio. Surf is compatible with async-std, and tokio.
https://github.com/seanmonstar/reqwest/issues/719#issuecomment-558758637

## Known Issues

This will break backwards compatibility in the API. Specifically in regards to the removal of the `ReqwestError` variant.
It is not abstracted in `HttpClientError` as a `string` so going forward, any changes to the http client shouldn't have an impact on the public API.