### PR TITLE
Fix: Add missing frame effect and promo type variants

### DIFF
--- a/src/card/frame_effect.rs
+++ b/src/card/frame_effect.rs
@@ -65,6 +65,8 @@ pub enum FrameEffect {
     UpsideDownDfc,
     /// The waxing and waning crescent moon transform marks.
     MoonReverseMoonDfc,
+    /// The cards have the enchantment frame effect.
+    Enchantment,
     /// A full art frame. Undocumented and unsupported for search.
     FullArt,
     /// A nyxborn card frame. Undocumented and unsupported for search.
@@ -132,6 +134,7 @@ impl std::fmt::Display for FrameEffect {
                 ConvertDfc => "convertdfc",
                 FanDfc => "fandfc",
                 UpsideDownDfc => "upsidedowndfc",
+                Enchantment => "enchantment",
                 FullArt => "fullart",
                 Nyxborn => "nyxborn",
                 WaxingAndWaningMoonDfc => "waxingandwaningmoondfc",

--- a/src/card/promo_types.rs
+++ b/src/card/promo_types.rs
@@ -52,6 +52,7 @@ pub enum PromoType {
     Judgegift,
     League,
     Magnified,
+    Manafoil,
     Mediainsert,
     Moonlitland,
     Neonink,

--- a/src/card/promo_types.rs
+++ b/src/card/promo_types.rs
@@ -79,6 +79,7 @@ pub enum PromoType {
     Setextension,
     Setpromo,
     Silverfoil,
+    Sldbonus,
     Stamped,
     Starterdeck,
     Stepandcompleat,

--- a/tests/variants-feature/unknown_variants.rs
+++ b/tests/variants-feature/unknown_variants.rs
@@ -153,6 +153,7 @@ fn match_on_promo_type(f: PromoType) {
         PromoType::Judgegift => todo!(),
         PromoType::League => todo!(),
         PromoType::Magnified => todo!(),
+        PromoType::Manafoil => todo!(),
         PromoType::Mediainsert => todo!(),
         PromoType::Moonlitland => todo!(),
         PromoType::Neonink => todo!(),

--- a/tests/variants-feature/unknown_variants.rs
+++ b/tests/variants-feature/unknown_variants.rs
@@ -39,6 +39,7 @@ fn match_on_frame_effect(f: FrameEffect) {
         FrameEffect::FanDfc => todo!(),
         FrameEffect::UpsideDownDfc => todo!(),
         FrameEffect::MoonReverseMoonDfc => todo!(),
+        FrameEffect::Enchantment => todo!(),
         FrameEffect::FullArt => todo!(),
         FrameEffect::Nyxborn => todo!(),
         FrameEffect::Booster => todo!(),
@@ -192,6 +193,7 @@ fn match_on_promo_type(f: PromoType) {
         PromoType::UpsideDownBack => todo!(),
         PromoType::Vault => todo!(),
         PromoType::Wizardsplaynetwork => todo!(),
+        PromoType::Sldbonus => todo!(),
         PromoType::Unknown(_) => todo!(),
     }
 }

--- a/tests/variants-feature/unknown_variants_slim.rs
+++ b/tests/variants-feature/unknown_variants_slim.rs
@@ -44,6 +44,7 @@ fn match_on_frame_effect(f: FrameEffect) {
         FrameEffect::FanDfc => todo!(),
         FrameEffect::UpsideDownDfc => todo!(),
         FrameEffect::MoonReverseMoonDfc => todo!(),
+        FrameEffect::Enchantment => todo!(),
         FrameEffect::FullArt => todo!(),
         FrameEffect::Nyxborn => todo!(),
         FrameEffect::Booster => todo!(),
@@ -197,6 +198,7 @@ fn match_on_promo_type(f: PromoType) {
         PromoType::UpsideDownBack => todo!(),
         PromoType::Vault => todo!(),
         PromoType::Wizardsplaynetwork => todo!(),
+        PromoType::Sldbonus => todo!(),
         PromoType::Unknown => todo!(),
     }
 }

--- a/tests/variants-feature/unknown_variants_slim.rs
+++ b/tests/variants-feature/unknown_variants_slim.rs
@@ -158,6 +158,7 @@ fn match_on_promo_type(f: PromoType) {
         PromoType::Judgegift => todo!(),
         PromoType::League => todo!(),
         PromoType::Magnified => todo!(),
+        PromoType::Manafoil => todo!(),
         PromoType::Mediainsert => todo!(),
         PromoType::Moonlitland => todo!(),
         PromoType::Neonink => todo!(),


### PR DESCRIPTION
I noticed two missing variants when trying to use the library to parse the most recent oracle cards dump (`oracle-cards-20241110100208.json`). One is the `enchantment` frame effect and the other is `sldbonus` promo type. I know the `unknown-variants` feature can be a catch-all for missing variants, but I thought it would be nice to keep updating the library as new variants in the various enums appear.

This PR adds `enchantment` frame effect and `sldbonus` promo type variants to their respective enums.