### PR TITLE
Add PromoType variants and missing doc comment on Search::query_string

### DIFF
--- a/src/card/promo_types.rs
+++ b/src/card/promo_types.rs
@@ -74,6 +74,7 @@ pub enum PromoType {
     Ravnicacity,
     Rebalanced,
     Release,
+    Resale,
     Ripplefoil,
     Schinesealtart,
     Scroll,

--- a/src/card/promo_types.rs
+++ b/src/card/promo_types.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 pub enum PromoType {
     Alchemy,
     Arenaleague,
+    Beginnerbox,
     Boosterfun,
     Boxtopper,
     Brawldeck,
@@ -82,6 +83,7 @@ pub enum PromoType {
     Silverfoil,
     Sldbonus,
     Stamped,
+    Startercollection,
     Starterdeck,
     Stepandcompleat,
     Storechampionship,

--- a/src/search.rs
+++ b/src/search.rs
@@ -48,6 +48,7 @@ pub trait Search {
     /// Write this search as the query for the given `Url`.
     fn write_query(&self, url: &mut Url) -> crate::Result<()>;
 
+    /// Returns the constructed query string for testing purposes.
     #[cfg(test)]
     fn query_string(&self) -> crate::Result<String> {
         let mut url = Url::parse("http://localhost")?;


### PR DESCRIPTION
`PromoType` variants `Beginnerbox` and `Startercollection` are part of the [Foundations (FDN)](https://scryfall.com/sets/fdn) set. `cargo test -- --ignored` revealed the missing `Resale` variant and the missing doc comments on `Search::query_string`.