### PR TITLE
Fix: Made related card component enum public and thus usable

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -45,6 +45,7 @@ pub use self::produced_mana::{ProducedMana, UnfinityMana};
 pub use self::promo_types::PromoType;
 pub use self::rarity::Rarity;
 pub use self::related_card::RelatedCard;
+pub use self::related_card::Component;
 pub use self::security_stamp::SecurityStamp;
 use crate::format::Format;
 use crate::list::{List, ListIter};

--- a/src/card/related_card.rs
+++ b/src/card/related_card.rs
@@ -38,6 +38,7 @@ pub struct RelatedCard {
 #[cfg_attr(test, serde(deny_unknown_fields))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+#[allow(missing_docs)]
 pub enum Component {
     Token,
     MeldPart,


### PR DESCRIPTION
The card component enum was not exported as public and thus not usable in downstream projects.
I assume this is due to an oversight, so i made id public.