### PR TITLE
Get card by Set and Number for Regional Promos

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -778,7 +778,7 @@ impl Card {
     }
 
 
-    /// Fetch a card by its set and number.
+    /// Fetch a card by its set and number. Can also be used for Region Specific Promo Cards.
     ///
     /// # Examples
     /// ```rust

--- a/src/card.rs
+++ b/src/card.rs
@@ -777,6 +777,25 @@ impl Card {
             .await
     }
 
+
+    /// Fetch a card by its set and number.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use scryfall::card::Card;
+    /// # tokio_test::block_on(async {
+    /// match Card::set_and_number_international("FIN", "J2").await {
+    ///     Ok(card) => assert_eq!(card.name, "Black Lotus"),
+    ///     Err(e) => panic!("{:?}", e),
+    /// }
+    /// # })
+    /// ```
+    pub async fn set_and_number_international(set_code: &str, international_number: &str) -> crate::Result<Card> {
+        Uri::from(CARDS_URL.join(&format!("{set_code}/{international_number}"))?)
+            .fetch()
+            .await
+    }
+
     /// Fetch a card by its multiverse id.
     ///
     /// # Examples

--- a/src/card.rs
+++ b/src/card.rs
@@ -784,8 +784,8 @@ impl Card {
     /// ```rust
     /// use scryfall::card::Card;
     /// # tokio_test::block_on(async {
-    /// match Card::set_and_number_international("FIN", "J2").await {
-    ///     Ok(card) => assert_eq!(card.name, "Black Lotus"),
+    /// match Card::set_and_number_international("RFIN", "J2").await {
+    ///     Ok(card) => assert_eq!(card.name, "Arcane Denial"),
     ///     Err(e) => panic!("{:?}", e),
     /// }
     /// # })


### PR DESCRIPTION
For international Promo cards, the Collector Id can contain letters as well as numbers, such as for [FFXIV Arcane Denial](https://scryfall.com/card/rfin/J2/ja/%E7%A7%98%E5%84%80%E3%81%AE%E5%90%A6%E5%AE%9A-(arcane-denial)) and [Legacy Championship Cards](https://scryfall.com/card/olgc/2016NA/badlands) As a result, the normal set_and_number function cant be used with these cards. I dint really see an alternative function that would cover my use case, and dint want to change the existing function for backwards comparability, so I added a new one. Not sure on the naming, there is probably something better.